### PR TITLE
chore: 기존 유효성 검사 클래스 분리

### DIFF
--- a/src/AuthAdmin.java
+++ b/src/AuthAdmin.java
@@ -54,13 +54,14 @@ public class AuthAdmin {
 
     public void signup() {
         adminList = fileIo.adminListReader(); // 기존 관리자목록 불러오기
+        ValidationUtils validationUtils = new ValidationUtils(); // 유효성 검사 클래스 분리
 
         String userId;
         do {
             System.out.println("\n===== 효성리조트 관리자 회원가입 =====");
             System.out.println("회원가입을 취소하시려면 \"취소\"를 입력해주세요.\n");
 
-            userId = getValidation("ID 입력 : ", "^[a-z]{1}[a-z0-9]{5,10}+$", "ID 정규식 미통과", "회원가입이 취소되었습니다.");
+            userId = validationUtils.getValidation(sc, AuthValidation.USER_ID);
             if (userId == null) return;
 
             // 동일 키값이 있는 경우 들어가면 X
@@ -70,11 +71,11 @@ public class AuthAdmin {
             }
         } while (userId == null);
 
-        String password = getValidation("비밀번호 입력 : ", "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@#$%^&+=~!]).{8,14}$", "PW 정규식 미통과", "회원가입이 취소되었습니다.");
-        if(password == null) return;
+        String password = validationUtils.getValidation(sc, AuthValidation.PASSWORD);
+        if (password == null) return;
 
-        String name = getValidation("이름 : ", "^[a-zA-Z가-힣]+$", "이름 정규식 미통과", "회원가입이 취소되었습니다.");
-        if(name == null) return;
+        String name = validationUtils.getValidation(sc, AuthValidation.NAME);
+        if (name == null) return;
 
         admin = new Admin(name, userId, password, true);
         adminList.put(userId, admin);
@@ -83,7 +84,7 @@ public class AuthAdmin {
 
         // 확인용 출력
         adminList.entrySet().stream()
-                .forEach(entry -> System.out.println("관리자 ID : " + entry.getKey() + "  | admin 정보 : " + entry.getValue()));
+                .forEach(entry -> System.out.println("[확인용 출력] 관리자 ID : " + entry.getKey() + "  | admin 정보 : " + entry.getValue()));
     }
 
     public void login() {
@@ -97,7 +98,7 @@ public class AuthAdmin {
         while (true) {
             System.out.print("ID 입력 : ");
             userId = sc.nextLine();
-            if(userId.equals("취소")) return;
+            if (userId.equals("취소")) return;
 
             System.out.print("PW 입력 : ");
             password = sc.nextLine();
@@ -111,37 +112,11 @@ public class AuthAdmin {
             }
         }
 
-        // 확인용 출력
-        System.out.println("전체 관리자 정보 (확인용)");
-        adminList.entrySet().stream()
-                .forEach(entry -> System.out.println("관리자 ID : " + entry.getKey() + " | admin 정보 : " + entry.getValue()));
-
         // 현재 로그인한 관리자 정보 출력(확인용)
         System.out.println("현재 로그인한 관리자 정보 출력 : " + admin.toString());
 
         menuAdmin = new MenuAdmin();
         menuAdmin.run(admin);
-    }
-
-    /**
-     * 유효성 검사
-     */
-    private String getValidation(String inputMessage, String regex, String failMessage, String exitMessage) {
-        String input;
-        while (true) {
-            System.out.print(inputMessage);
-            input = sc.nextLine();
-            if ("취소".equals(input)) {
-                System.out.println(exitMessage);
-                return null;
-            }
-            if (!input.matches(regex)) {
-                System.out.println(failMessage);
-                continue;
-            }
-            break;
-        }
-        return input;
     }
 }
 

--- a/src/AuthMember.java
+++ b/src/AuthMember.java
@@ -39,13 +39,14 @@ public class AuthMember {
 
     public void signup() {
         memberList = fileIo.memberListReader(); // 기존 회원목록 불러오기
+        ValidationUtils validationUtils = new ValidationUtils(); // 유효성 검사 클래스 분리
 
         String userId;
         do {
             System.out.println("\n===== 효성리조트 회원가입 =====");
             System.out.println("회원가입을 취소하시려면 \"취소\"를 입력해주세요.\n");
 
-            userId = getValidation("ID : ", "^[a-z]{1}[a-z0-9]{5,10}+$", "ID 정규식 미통과", "회원가입이 취소되었습니다.");
+            userId = validationUtils.getValidation(sc, AuthValidation.USER_ID);
             if (userId == null) return;
 
             // 동일 키값이 있는 경우 들어가면 X
@@ -55,13 +56,13 @@ public class AuthMember {
             }
         } while (userId == null);
 
-        String password = getValidation("비밀번호 : ", "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@#$%^&+=~!]).{8,14}$", "PW 정규식 미통과", "회원가입이 취소되었습니다.");
+        String password = validationUtils.getValidation(sc, AuthValidation.PASSWORD);
         if (password == null) return;
 
-        String name = getValidation("이름 : ", "^[a-zA-Z가-힣]+$", "이름 정규식 미통과", "회원가입이 취소되었습니다.");
+        String name = validationUtils.getValidation(sc, AuthValidation.NAME);
         if (name == null) return;
 
-        String phoneNumber = getValidation("전화번호 : ", "^01(?:0|1|[6-9])-(?:\\d{3}|\\d{4})-\\d{4}$", "전화번호 정규식 미통과", "회원가입이 취소되었습니다.");
+        String phoneNumber = validationUtils.getValidation(sc, AuthValidation.PHONE_NUMBER);
         if (phoneNumber == null) return;
 
         member = new Member(name, phoneNumber, userId, password, false);
@@ -71,7 +72,7 @@ public class AuthMember {
 
         // 확인용 출력
         memberList.entrySet().stream()
-                .forEach(entry -> System.out.println("회원 ID : " + entry.getKey() + " | member 정보 : " + entry.getValue()));
+                .forEach(entry -> System.out.println("[확인용 출력] 회원 ID : " + entry.getKey() + " | member 정보 : " + entry.getValue()));
     }
 
     public void login() {
@@ -99,11 +100,6 @@ public class AuthMember {
             }
         }
 
-        // 확인용 출력(전체정보 - 확인용)
-        System.out.println("전체 회원 정보 (확인용)");
-        memberList.entrySet().stream()
-                .forEach(entry -> System.out.println("회원 ID : " + entry.getKey() + " | member 정보 : " + entry.getValue()));
-
         // 현재 로그인한 회원 정보 출력(확인용)
         System.out.println("현재 로그인한 회원 정보 출력 : " + member.toString());
 
@@ -111,24 +107,4 @@ public class AuthMember {
         menuMember.run(member);
     }
 
-    /**
-     * 유효성 검사
-     */
-    private String getValidation(String inputMessage, String regex, String failMessage, String exitMessage) {
-        String input;
-        while (true) {
-            System.out.print(inputMessage);
-            input = sc.nextLine();
-            if ("취소".equals(input)) {
-                System.out.println(exitMessage);
-                return null;
-            }
-            if (!input.matches(regex)) {
-                System.out.println(failMessage);
-                continue;
-            }
-            break;
-        }
-        return input;
-    }
 }

--- a/src/AuthValidation.java
+++ b/src/AuthValidation.java
@@ -1,0 +1,34 @@
+public enum AuthValidation {
+    USER_ID("ID 입력 (소문자 알파벳, 숫자 조합 6~10자리) : ", "^[a-z][a-z0-9]{5,10}$", "ID 형식에 맞게 입력해주세요.", "회원가입이 취소되었습니다."),
+    PASSWORD("비밀번호 입력 (대소문자 알파벳, 숫자, 특수문자 조합 8~14자리) : ", "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@#$%^&+=~!]).{8,14}$", "비밀번호 형식에 맞게 입력해주세요.", "회원가입이 취소되었습니다."),
+    NAME("이름 (한글 문자) : ", "^[가-힣]*$", "이름 형식에 맞게 입력해주세요.", "회원가입이 취소되었습니다."),
+    PHONE_NUMBER("전화번호 (휴대전화 번호 형식에 맞는 번호) : ", "^01(?:0|1|[6-9])-(?:\\d{3}|\\d{4})-\\d{4}$", "전화번호 형식에 맞게 입력해주세요.", "회원가입이 취소되었습니다.");
+
+    private final String inputMessage;
+    private final String regex;
+    private final String failureMessage;
+    private final String cancellationMessage;
+
+    AuthValidation(String inputMessage, String regex, String failureMessage, String cancellationMessage) {
+        this.inputMessage = inputMessage;
+        this.regex = regex;
+        this.failureMessage = failureMessage;
+        this.cancellationMessage = cancellationMessage;
+    }
+
+    public String getInputMessage() {
+        return inputMessage;
+    }
+
+    public String getRegex() {
+        return regex;
+    }
+
+    public String getFailureMessage() {
+        return failureMessage;
+    }
+
+    public String getCancellationMessage() {
+        return cancellationMessage;
+    }
+}

--- a/src/MenuAdmin.java
+++ b/src/MenuAdmin.java
@@ -37,6 +37,7 @@ public class MenuAdmin {
                     }
                     break;
                 }
+                /*
                 case 2: {
                     System.out.println("1. 예약 목록 전체 조회, 2. 특정 회원 예약내역 조회");
                     int pointerReservationManage = Integer.parseInt(sc.nextLine());
@@ -75,6 +76,7 @@ public class MenuAdmin {
                     }
                     break;
                 }
+                */
                 case 5: {
                     break;
                 }
@@ -121,7 +123,7 @@ public class MenuAdmin {
             System.out.println(deleteName + " 회원을 찾을 수 없습니다.");
         }
     }
-
+/*
     public void getAllReservationInfo() {
         // 예약하기 제대로 안되서 미확인
         System.out.println("1. 수서점  2. 혜화점");
@@ -213,4 +215,6 @@ public class MenuAdmin {
     public void getAllProductRevenue() {
 
     }
+
+ */
 }

--- a/src/ValidationUtils.java
+++ b/src/ValidationUtils.java
@@ -1,0 +1,23 @@
+import java.util.Scanner;
+
+public class ValidationUtils {
+
+    public String getValidation(Scanner sc, AuthValidation validation) {
+
+        String input;
+        while (true) {
+            System.out.print(validation.getInputMessage());
+            input = sc.nextLine();
+            if ("취소".equals(input)) {
+                System.out.println(validation.getCancellationMessage());
+                return null;
+            }
+            if (!input.matches(validation.getRegex())) {
+                System.out.println(validation.getFailureMessage());
+                continue;
+            }
+            break;
+        }
+        return input;
+    }
+}


### PR DESCRIPTION
## 구현 기능

- 기존 유효성 검사 클래스 분리
- 정규표현식 및 메세지 enum 분리

## 논의
- 유효성 검사 로직을 클래스로 따로 분리했습니다. 
- 정규표현식과 메세지와 같은 부분은 변동이 없기에, 따로 enum으로 분리시켰습니다.
- 부족한 부분이나, 놓친 부분이 있다면 리뷰 부탁드립니다!